### PR TITLE
Update LDC version to new 1.1.0 release

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ldc2
-version: "1.1.0-beta6-snap0"
+version: "1.1.0"
 summary: D compiler with LLVM backend
 description: |
     LDC is a portable compiler for the D programming Language, with
@@ -26,7 +26,7 @@ apps:
 parts:
   ldc:
     source: git://github.com/ldc-developers/ldc.git
-    source-tag: v1.1.0-beta6
+    source-tag: v1.1.0
     plugin: cmake
     stage:
     - -etc/ldc2.conf


### PR DESCRIPTION
LDC 1.1.0 is finally out of beta!

The snap version number has been tweaked to remove the `snapN` component since the revision number of released snap packages should already give enough information to decide between versions.