### PR TITLE
Replace ldc build-package with bootstrap build of LDC 0.17.2

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,20 +28,39 @@ parts:
     source: git://github.com/ldc-developers/ldc.git
     source-tag: v1.1.0
     plugin: cmake
+    configflags:
+    - -DD_COMPILER=../../ldc-bootstrap/build/bin/ldmd2
     stage:
     - -etc/ldc2.conf
     build-packages:
     - build-essential
-    - ldc
     - llvm-dev
     - libconfig++-dev
     - libedit-dev
     - zlib1g-dev
     stage-packages:
     - libconfig9
-    - libphobos2-ldc68
+    after:
+    - ldc-bootstrap
   ldc-config:
     plugin: dump
     source: ldc-config
     organize:
       ldc2.conf: etc/ldc2.conf
+
+  ldc-bootstrap:
+    source: git://github.com/ldc-developers/ldc.git
+    source-tag: v0.17.2
+    plugin: cmake
+    stage:
+    - -*
+    prime:
+    - -*
+    build-packages:
+    - build-essential
+    - llvm-dev
+    - libconfig++-dev
+    - libedit-dev
+    - zlib1g-dev
+    stage-packages:
+    - libconfig9


### PR DESCRIPTION
This ensures that the ability to build the snap is not conditional on being on a system with LDC pre-packaged.  It also makes sure that the bootstrap is based on the latest C++-frontend LDC release rather than the outdated 0.17.1 release currently available in Ubuntu 16.04.