### PR TITLE
Explicitly specify the LLVM version to use

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
     of D2, and uses the LLVM Core libraries for code generation.
 
     This release of LDC uses the D2.071.2 frontend, runtime and
-    standard library.
+    standard library, and the LLVM 3.8 backend.
 
 confinement: classic
 grade: devel
@@ -34,7 +34,7 @@ parts:
     - -etc/ldc2.conf
     build-packages:
     - build-essential
-    - llvm-dev
+    - llvm-3.8-dev
     - libconfig++-dev
     - libedit-dev
     - zlib1g-dev
@@ -58,7 +58,7 @@ parts:
     - -*
     build-packages:
     - build-essential
-    - llvm-dev
+    - llvm-3.8-dev
     - libconfig++-dev
     - libedit-dev
     - zlib1g-dev


### PR DESCRIPTION
It seems saner to be explicit about the LLVM version than to rely on a distro-dependent version that may change.  Ubuntu 16.04 does not provide a package for LLVM 3.9, so 3.8 is the most recent version that can be used unless the snap builds LLVM itself.  This may be worth implementing in future, but it would add heavily to the build time and so has been avoided for now.