### PR TITLE
Upgrade bootstrap LDC to 0.17.3

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -50,7 +50,7 @@ parts:
 
   ldc-bootstrap:
     source: git://github.com/ldc-developers/ldc.git
-    source-tag: v0.17.2
+    source-tag: v0.17.3
     plugin: cmake
     stage:
     - -*


### PR DESCRIPTION
This brings the bootstrap LDC compiler up to date with the latest 0.17.x release (just released!):
https://github.com/ldc-developers/ldc/releases/tag/v0.17.3

Thanks for the heads-up @JohanEngelen :-)