### PR TITLE
Remove quotes from snapcraft.yaml `version:` field

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ldc2
-version: "1.1.0"
+version: 1.1.0
 summary: D compiler with LLVM backend
 description: |
     LDC is a portable compiler for the D programming Language, with


### PR DESCRIPTION
These seem to be completely superfluous and unnecessary.