### PR TITLE
Replace llvm-dev build-package with fresh build of LLVM 3.9.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,7 @@ parts:
     - -DD_COMPILER=../../ldc-bootstrap/build/bin/ldmd2
     - -DCMAKE_BUILD_TYPE=Release
     - -DLLVM_ROOT_DIR=../../llvm/install
+    - -DLDC_INSTALL_LTOPLUGIN=ON
     stage:
     - -etc/ldc2.conf
     build-packages:
@@ -73,9 +74,11 @@ parts:
     plugin: cmake
     configflags:
     - -DCMAKE_BUILD_TYPE=Release
+    - -DLLVM_BINUTILS_INCDIR=/usr/include
     stage:
     - -*
     prime:
     - -*
     build-packages:
+    - binutils-dev
     - build-essential

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,11 +28,11 @@ parts:
     configflags:
     - -DD_COMPILER=../../ldc-bootstrap/build/bin/ldmd2
     - -DCMAKE_BUILD_TYPE=Release
+    - -DLLVM_ROOT_DIR=../../llvm/install
     stage:
     - -etc/ldc2.conf
     build-packages:
     - build-essential
-    - llvm-dev
     - libconfig++-dev
     - libedit-dev
     - zlib1g-dev
@@ -40,6 +40,7 @@ parts:
     - libconfig9
     after:
     - ldc-bootstrap
+    - llvm
   ldc-config:
     plugin: dump
     source: ldc-config
@@ -52,15 +53,29 @@ parts:
     plugin: cmake
     configflags:
     - -DCMAKE_BUILD_TYPE=Release
+    - -DLLVM_ROOT_DIR=../../llvm/install
     stage:
     - -*
     prime:
     - -*
     build-packages:
     - build-essential
-    - llvm-dev
     - libconfig++-dev
     - libedit-dev
     - zlib1g-dev
     stage-packages:
     - libconfig9
+    after:
+    - llvm
+
+  llvm:
+    source: http://releases.llvm.org/3.9.1/llvm-3.9.1.src.tar.xz
+    plugin: cmake
+    configflags:
+    - -DCMAKE_BUILD_TYPE=Release
+    stage:
+    - -*
+    prime:
+    - -*
+    build-packages:
+    - build-essential


### PR DESCRIPTION
This ensures the snap will use the latest stable LLVM release supported by LDC.  It also removes one more assumption about what libraries are available on the system on which the snap is built.

@klickverbot @JohanEngelen does this look sane for you in terms of the build setup of LLVM itself?