### PR TITLE
Set snap package grade to stable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
     of D2, and uses the LLVM Core libraries for code generation.
 
 confinement: classic
-grade: devel
+grade: stable
 
 apps:
   ldc2:


### PR DESCRIPTION
Since the latest feature additions put us on par with other official LDC packages, this seems a reasonable change to make.  It makes it possible to publish the snap package to the 'candidate' and 'stable' channels as well as 'edge' and 'beta'.