### PR TITLE
Ensure app command paths are relative to base directory of snap package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,13 +12,13 @@ grade: stable
 
 apps:
   ldc2:
-    command: ldc2
+    command: bin/ldc2
   ldmd2:
-    command: ldmd2
+    command: bin/ldmd2
   ldc-profdata:
-    command: ldc-profdata
+    command: bin/ldc-profdata
   ldc-prune-cache:
-    command: ldc-prune-cache
+    command: bin/ldc-prune-cache
 
 parts:
   ldc:


### PR DESCRIPTION
This is required by snapcraft 2.27 or later, which will no longer add any environment variables (such as additions to `PATH`) for classic snaps.  See:
https://lists.ubuntu.com/archives/snapcraft/2017-February/003303.html

... for an explanation.