### PR TITLE
Remove build-essential from build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,7 @@ parts:
     stage:
     - -etc/ldc2.conf
     build-packages:
-    - build-essential
+    - gcc
     - libconfig++-dev
     - libedit-dev
     - zlib1g-dev
@@ -60,7 +60,7 @@ parts:
     prime:
     - -*
     build-packages:
-    - build-essential
+    - g++
     - libconfig++-dev
     - libedit-dev
     - zlib1g-dev
@@ -81,4 +81,4 @@ parts:
     - -*
     build-packages:
     - binutils-dev
-    - build-essential
+    - g++


### PR DESCRIPTION
Including this is not necessary: it suffices to have `g++` available for building LLVM and the bootstrap LDC, and `gcc` for linking the packaged LDC.