### PR TITLE
Update LDC version to v1.1.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ldc2
-version: 1.1.1-beta1
+version: 1.1.1
 summary: D compiler with LLVM backend
 description: |
     LDC is a portable compiler for the D programming Language, with
@@ -8,7 +8,7 @@ description: |
     of D2, and uses the LLVM Core libraries for code generation.
 
 confinement: classic
-grade: devel
+grade: stable
 
 apps:
   ldc2:
@@ -23,7 +23,7 @@ apps:
 parts:
   ldc:
     source: git://github.com/ldc-developers/ldc.git
-    source-tag: v1.1.1-beta1
+    source-tag: v1.1.1
     plugin: cmake
     configflags:
     - -DD_COMPILER=../../ldc-bootstrap/build/bin/ldmd2


### PR DESCRIPTION
v1.1.1-beta1 proved a viable solution to the position-independent code issue (cf. ldc-developers/ldc2.snap#15) so has been updated to the final v1.1.1 release.

This patch updates the snap-package definition accordingly and re-grades the snap once more as `stable`, re-enabling the possibility to upload to the candidate and release channels.