### PR TITLE
Add -Wa,-mrelax-relocations=no to CMAKE_C_FLAGS_RELEASE for LDC build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,8 +28,10 @@ parts:
     configflags:
     - -DD_COMPILER=../../ldc-bootstrap/build/bin/ldmd2
     - -DCMAKE_BUILD_TYPE=Release
+    - -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -Wa,-mrelax-relocations=no'
     - -DLLVM_ROOT_DIR=../../llvm/install
     - -DLDC_INSTALL_LTOPLUGIN=ON
+    - -DCMAKE_VERBOSE_MAKEFILE=1
     stage:
     - -etc/ldc2.conf
     build-packages:


### PR DESCRIPTION
This should address the finnicky binutils issues observed when the snap is installed on Ubuntu 14.04.  See:
https://bugs.launchpad.net/snapcraft/+bug/1668424

Fixes ldc-developers/ldc2.snap#17.