### PR TITLE
Explicitly specify git as source-type for ldc and ldc-bootstrap parts

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,7 @@ parts:
   ldc:
     source: https://github.com/ldc-developers/ldc.git
     source-tag: v1.1.1
+    source-type: git
     plugin: cmake
     configflags:
     - -DD_COMPILER=../../ldc-bootstrap/build/bin/ldmd2
@@ -53,6 +54,7 @@ parts:
   ldc-bootstrap:
     source: https://github.com/ldc-developers/ldc.git
     source-tag: v0.17.3
+    source-type: git
     plugin: cmake
     configflags:
     - -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
This will hopefully resolve the Launchpad built system's issues when trying to clone the git repositories.

In support of https://github.com/ldc-developers/ldc2.snap/issues/21.