### PR TITLE
Update copyright years to 2017 in snap/license.txt

### DIFF
--- a/snap/license.txt
+++ b/snap/license.txt
@@ -48,7 +48,7 @@ Full license texts
 
 -- LDC license -----------------------------------------------------------------
 
-Copyright (c) 2007-2016 LDC Team.
+Copyright (c) 2007-2017 LDC Team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -- DMD license -----------------------------------------------------------------
 
-Copyright (c) 1999-2016 by Digital Mars written by Walter Bright.
+Copyright (c) 1999-2017 by Digital Mars written by Walter Bright.
 
 DMD is released under the terms of the Boost Software License - Version 1.0.
 
@@ -114,7 +114,7 @@ DEALINGS IN THE SOFTWARE.
 University of Illinois/NCSA
 Open Source License
 
-Copyright (c) 2003-2016 University of Illinois at Urbana-Champaign.
+Copyright (c) 2003-2017 University of Illinois at Urbana-Champaign.
 All rights reserved.
 
 Developed by:


### PR DESCRIPTION
This brings the text of the license file in line with the upstream 1.2.0 release.