### PR TITLE
Add aliases for ldmd2, ldc-profdata and ldc-prune-cache to 1.1.x release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,10 +15,13 @@ apps:
     command: bin/ldc2
   ldmd2:
     command: bin/ldmd2
+    aliases: [ldmd2]
   ldc-profdata:
     command: bin/ldc-profdata
+    aliases: [ldc-profdata]
   ldc-prune-cache:
     command: bin/ldc-prune-cache
+    aliases: [ldc-prune-cache]
 
 parts:
   ldc:


### PR DESCRIPTION
This should make it possible for users to invoke these commands in the normal way instead of via `ldc2.appname`.  Note that the user must still explicitly request the alias be enabled, e.g.:

    sudo snap alias ldc2 ldmd2

... after which it should be possible to call `ldmd2` as usual.

This patch was already committed to the 1.2.x release series, but it seems worth backporting, even though the 1.1.1 release is still manual-only in its builds due to https://bugs.launchpad.net/launchpad-buildd/+bug/1663920.