### PR TITLE
Update to LDC 1.3.0 stable release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ldc2
-version: 1.3.0-beta2
+version: 1.3.0
 summary: D compiler with LLVM backend
 description: |
     LDC is a portable compiler for the D programming Language, with
@@ -8,7 +8,7 @@ description: |
     of D2, and uses the LLVM Core libraries for code generation.
 
 confinement: classic
-grade: devel
+grade: stable
 
 apps:
   ldc2:
@@ -26,7 +26,7 @@ apps:
 parts:
   ldc:
     source: https://github.com/ldc-developers/ldc.git
-    source-tag: v1.3.0-beta2
+    source-tag: v1.3.0
     source-type: git
     plugin: cmake
     configflags:


### PR DESCRIPTION
Besides the LDC version update, the package has been restored to stable grade, allowing it to be published to candidate and release channels in the snap store.