### PR TITLE
Add MULTILIB support to the LDC build

### DIFF
--- a/ldc-config/ldc2.conf
+++ b/ldc-config/ldc2.conf
@@ -10,6 +10,9 @@ default:
         "-I%%ldcbinarypath%%/../include/d/ldc",
         "-I%%ldcbinarypath%%/../include/d",
         "-L-L%%ldcbinarypath%%/../lib",
+        "-L-L%%ldcbinarypath%%/../lib32",
+        "-L-L%%ldcbinarypath%%/../lib64",
+        "-L--no-warn-search-mismatch",
         "-defaultlib=phobos2-ldc,druntime-ldc",
         "-debuglib=phobos2-ldc-debug,druntime-ldc-debug"
     ];

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,11 +35,12 @@ parts:
     - -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -Wa,-mrelax-relocations=no'
     - -DLLVM_ROOT_DIR=../../llvm/install
     - -DLDC_INSTALL_LTOPLUGIN=ON
+    - -DMULTILIB=ON
     - -DCMAKE_VERBOSE_MAKEFILE=1
     stage:
     - -etc/ldc2.conf
     build-packages:
-    - gcc
+    - gcc-multilib
     - libconfig++-dev
     - libedit-dev
     - zlib1g-dev
@@ -62,12 +63,13 @@ parts:
     configflags:
     - -DCMAKE_BUILD_TYPE=Release
     - -DLLVM_ROOT_DIR=../../llvm/install
+    - -DMULTILIB=ON
     stage:
     - -*
     prime:
     - -*
     build-packages:
-    - g++
+    - g++-multilib
     - libconfig++-dev
     - libedit-dev
     - zlib1g-dev


### PR DESCRIPTION
This should ensure that both 32- and 64-bit libraries are available in the snap package, whatever the target architecture of the build.

Submitted against the 1.1 branch, with the aim that it be merged into all higher-version branches.