### PR TITLE
Revert "Add MULTILIB support to the LDC build"

### DIFF
--- a/ldc-config/ldc2.conf
+++ b/ldc-config/ldc2.conf
@@ -10,9 +10,6 @@ default:
         "-I%%ldcbinarypath%%/../include/d/ldc",
         "-I%%ldcbinarypath%%/../include/d",
         "-L-L%%ldcbinarypath%%/../lib",
-        "-L-L%%ldcbinarypath%%/../lib32",
-        "-L-L%%ldcbinarypath%%/../lib64",
-        "-L--no-warn-search-mismatch",
         "-defaultlib=phobos2-ldc,druntime-ldc",
         "-debuglib=phobos2-ldc-debug,druntime-ldc-debug"
     ];

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,12 +35,11 @@ parts:
     - -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -Wa,-mrelax-relocations=no'
     - -DLLVM_ROOT_DIR=../../llvm/install
     - -DLDC_INSTALL_LTOPLUGIN=ON
-    - -DMULTILIB=ON
     - -DCMAKE_VERBOSE_MAKEFILE=1
     stage:
     - -etc/ldc2.conf
     build-packages:
-    - gcc-multilib
+    - gcc
     - libconfig++-dev
     - libedit-dev
     - zlib1g-dev
@@ -63,13 +62,12 @@ parts:
     configflags:
     - -DCMAKE_BUILD_TYPE=Release
     - -DLLVM_ROOT_DIR=../../llvm/install
-    - -DMULTILIB=ON
     stage:
     - -*
     prime:
     - -*
     build-packages:
-    - g++-multilib
+    - g++
     - libconfig++-dev
     - libedit-dev
     - zlib1g-dev


### PR DESCRIPTION
Enabling multilib for 32-bit builds currently results in build failure due to a conflict between the multilib `_64` suffix and modules that normally have `_64` in their name.

Although it might be possible to still enable multilib for 64-bit builds only, this is put off for a later time in order to not block other new features from being possible to roll out.

This reverts commit c2770f024b67b2ec90cce3cf551850bacd9ed575.