### PR TITLE
Run ctest after LDC build is complete

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,6 +36,7 @@ parts:
     - -DLLVM_ROOT_DIR=../../llvm/install
     - -DLDC_INSTALL_LTOPLUGIN=ON
     - -DCMAKE_VERBOSE_MAKEFILE=1
+    install: ctest --verbose
     stage:
     - -etc/ldc2.conf
     build-packages:
@@ -46,6 +47,7 @@ parts:
     stage-packages:
     - libconfig9
     after:
+    - ctest-setup
     - ldc-bootstrap
     - llvm
   ldc-config:
@@ -89,3 +91,15 @@ parts:
     build-packages:
     - binutils-dev
     - g++
+
+  ctest-setup:
+    plugin: nil
+    stage:
+    - -*
+    prime:
+    - -*
+    build-packages:
+    - gdb
+    - python-pip
+    - unzip
+    prepare: pip install lit


### PR DESCRIPTION
This patch adds a new `ctest-setup` part to install all dependencies for the `ctest` collection of tests defined for LDC.  The somewhat misnamed `install:` scriptlet (which actually runs post-install) is then used in the `ldc` part to invoke `ctest` itself, in verbose mode so that all the tests will be clearly described in the build log.

This should ensure that the packaged compiler is guaranteed to have at least passed the standard battery of tests on the build platform.

Addresses part of https://github.com/ldc-developers/ldc2.snap/issues/29.