### PR TITLE
Ensure correct python dependencies are installed for ctest-setup

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,6 +100,7 @@ parts:
     - -*
     build-packages:
     - gdb
-    - python-pip
+    - python3-pip
+    - python3-setuptools
     - unzip
     prepare: pip install lit


### PR DESCRIPTION
This patch updates to installing python3 packages (since python3 is the version used in the core snap) and ensures `setuptools` is available to packages installed using `pip`.

This should fix current Launchpad build failures for the snap package.

Part of https://github.com/ldc-developers/ldc2.snap/issues/29.