### PR TITLE
Revert python3 build-packages to python

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,7 +100,7 @@ parts:
     - -*
     build-packages:
     - gdb
-    - python3-pip
-    - python3-setuptools
+    - python-pip
+    - python-setuptools
     - unzip
     prepare: pip install lit


### PR DESCRIPTION
~~This corrects an oversight in 5d7074e4c5c9eb59a53e459a21f96b67f6b0c0ca: the `python3-pip` package installs `pip3`, not `pip`.~~

Since the `ctest` invocation of `lit` expects python 2 and not python3, the changes introduced in 5d7074e4c5c9eb59a53e459a21f96b67f6b0c0ca are unworkable in practice.  This patch therefore ensures that `python-pip` and `python-setuptools` are used.  Let this be a lesson on the value of separation of concerns in patches, since if the previous one had merely added `python-setuptools` as a build dependency, it would probably have worked just fine ... ;-)

Part of https://github.com/ldc-developers/ldc2.snap/issues/29.