### PR TITLE
Exclude std.net.curl unittests when invoking ctest

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,7 @@ parts:
     - -DLLVM_ROOT_DIR=../../llvm/install
     - -DLDC_INSTALL_LTOPLUGIN=ON
     - -DCMAKE_VERBOSE_MAKEFILE=1
-    install: ctest --verbose
+    install: ctest --output-on-failure --verbose -E "std\.net\.curl"
     stage:
     - -etc/ldc2.conf
     build-packages:


### PR DESCRIPTION
The `std.net.curl` unittests hang indefinitely when run by Launchpad's build daemon, which probably blocks opening the local port used by the tests.  Excluding this one set of unittests should probably prevent the test suite from hanging.

Part of https://github.com/ldc-developers/ldc2.snap/issues/29.