### PR TITLE
Update to LDC 1.4.0 stable release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ldc2
-version: 1.3.0
+version: 1.4.0
 summary: D compiler with LLVM backend
 description: |
     LDC is a portable compiler for the D programming Language, with
@@ -16,6 +16,9 @@ apps:
   ldmd2:
     command: bin/ldmd2
     aliases: [ldmd2]
+  ldc-build-runtime:
+    command: bin/ldc-build-runtime
+    aliases: [ldc-build-runtime]
   ldc-profdata:
     command: bin/ldc-profdata
     aliases: [ldc-profdata]
@@ -26,7 +29,7 @@ apps:
 parts:
   ldc:
     source: https://github.com/ldc-developers/ldc.git
-    source-tag: v1.3.0
+    source-tag: v1.4.0
     source-type: git
     plugin: cmake
     configflags:


### PR DESCRIPTION
In addition to the LDC version update, the `ldc-build-runtime` helper utility has been added to the list of available commands.