### PR TITLE
Update to LDC fork of LLVM 5.0.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,7 +58,7 @@ parts:
 
   ldc-bootstrap:
     source: https://github.com/ldc-developers/ldc.git
-    source-tag: v0.17.4
+    source-tag: v0.17.5
     source-type: git
     plugin: cmake
     configflags:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,7 @@ parts:
     - -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -Wa,-mrelax-relocations=no'
     - -DLLVM_ROOT_DIR=../../llvm/install
     - -DLDC_INSTALL_LTOPLUGIN=ON
+    - -DLDC_WITH_LLD=OFF
     - -DCMAKE_VERBOSE_MAKEFILE=1
     install: ctest --output-on-failure --verbose -E "std\.net\.curl|lit-tests"
     stage:
@@ -80,7 +81,7 @@ parts:
 
   llvm:
     source: https://github.com/ldc-developers/llvm.git
-    source-tag: ldc-v4.0.1
+    source-tag: ldc-v5.0.1
     source-type: git
     plugin: cmake
     configflags:


### PR DESCRIPTION
This will bring the 1.4 package up to date with the latest stable LLVM release, and lay the ground for the 1.5, 1.6 and 1.7 package releases.

The bootstrap compiler has been updated to 0.17.5 to support the LLVM 5.x.x.