### PR TITLE
Update to LDC 1.5.0 stable release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ldc2
-version: 1.4.0
+version: 1.5.0
 summary: D compiler with LLVM backend
 description: |
     LDC is a portable compiler for the D programming Language, with
@@ -29,7 +29,7 @@ apps:
 parts:
   ldc:
     source: https://github.com/ldc-developers/ldc.git
-    source-tag: v1.4.0
+    source-tag: v1.5.0
     source-type: git
     plugin: cmake
     configflags:
@@ -38,7 +38,6 @@ parts:
     - -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -Wa,-mrelax-relocations=no'
     - -DLLVM_ROOT_DIR=../../llvm/install
     - -DLDC_INSTALL_LTOPLUGIN=ON
-    - -DLDC_WITH_LLD=OFF
     - -DCMAKE_VERBOSE_MAKEFILE=1
     install: ctest --output-on-failure --verbose -E "std\.net\.curl|lit-tests"
     stage:


### PR DESCRIPTION
As part of this update we can remove the `LDC_WITH_LLD=OFF` option, as it is no longer required to avoid build errors.