### PR TITLE
Ensure druntime and phobos are built with link-time optimization (LTO)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,9 +34,11 @@ parts:
     plugin: cmake
     configflags:
     - -DD_COMPILER=../../ldc-bootstrap/build/bin/ldmd2
+    - -DD_FLAGS='-w;-flto=thin'
     - -DCMAKE_BUILD_TYPE=Release
     - -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -Wa,-mrelax-relocations=no'
     - -DLLVM_ROOT_DIR=../../llvm/install
+    - -DBUILD_LTO_LIBS=ON
     - -DLDC_INSTALL_LTOPLUGIN=ON
     - -DCMAKE_VERBOSE_MAKEFILE=1
     install: ctest --output-on-failure --verbose -E "std\.net\.curl|std\.process|lit-tests"


### PR DESCRIPTION
This should bring the snap package closer in line with the packages and tarballs distributed via GitHub.