### PR TITLE
Re-enable MULTILIB support for the LDC build

### DIFF
--- a/ldc-config/ldc2.conf
+++ b/ldc-config/ldc2.conf
@@ -10,6 +10,9 @@ default:
         "-I%%ldcbinarypath%%/../include/d/ldc",
         "-I%%ldcbinarypath%%/../include/d",
         "-L-L%%ldcbinarypath%%/../lib",
+        "-L-L%%ldcbinarypath%%/../lib32",
+        "-L-L%%ldcbinarypath%%/../lib64",
+        "-L--no-warn-search-mismatch",
         "-defaultlib=phobos2-ldc,druntime-ldc",
         "-debuglib=phobos2-ldc-debug,druntime-ldc-debug"
     ];

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,12 +40,14 @@ parts:
     - -DLLVM_ROOT_DIR=../../llvm/install
     - -DBUILD_LTO_LIBS=ON
     - -DLDC_INSTALL_LTOPLUGIN=ON
+    - -DMULTILIB=ON
     - -DCMAKE_VERBOSE_MAKEFILE=1
     install: ctest --output-on-failure --verbose -E "std\.net\.curl|std\.process|lit-tests"
     stage:
     - -etc/ldc2.conf
     build-packages:
-    - gcc
+    - gcc-multilib
+    - g++-multilib
     - libedit-dev
     - zlib1g-dev
     after:
@@ -66,6 +68,7 @@ parts:
     configflags:
     - -DCMAKE_BUILD_TYPE=Release
     - -DLLVM_ROOT_DIR=../../llvm/install
+    - -DMULTILIB=ON
     stage:
     - -*
     prime:


### PR DESCRIPTION
This should ensure that both 32- and 64-bit libraries are available in the snap package, whatever the target architecture of the build.  With various issues addressed since the last time we tried this, it seems
worth repeating the attempt.

`ldc2.conf` has been updated to handle all possible expected library paths: `lib` for native, `lib32` for 32-bit libraries in a 64-bit build, and `lib64` for 64-bit libraries in a 32-bit build.