### PR TITLE
Only enable multilib for the packaged compiler

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,7 +68,6 @@ parts:
     configflags:
     - -DCMAKE_BUILD_TYPE=Release
     - -DLLVM_ROOT_DIR=../../llvm/install
-    - -DMULTILIB=ON
     stage:
     - -*
     prime:


### PR DESCRIPTION
There is no need to enable multilib support for the bootstrap compiler.  This corrects an oversight in the previous patch.