### PR TITLE
Update ldc2.conf to provide post-switches and rpath

### DIFF
--- a/ldc-config/ldc2.conf
+++ b/ldc-config/ldc2.conf
@@ -4,16 +4,21 @@
 // The default group is required
 default:
 {
-    // 'switches' holds array of string that are appends to the command line
-    // arguments before they are parsed.
+    // default switches injected before all explicit command-line switches
     switches = [
+        "-defaultlib=phobos2-ldc,druntime-ldc",
+    ];
+
+    // default switches appended after all explicit command-line switches
+    post-switches = [
         "-I%%ldcbinarypath%%/../include/d/ldc",
         "-I%%ldcbinarypath%%/../include/d",
         "-L-L%%ldcbinarypath%%/../lib",
         "-L-L%%ldcbinarypath%%/../lib32",
         "-L-L%%ldcbinarypath%%/../lib64",
         "-L--no-warn-search-mismatch",
-        "-defaultlib=phobos2-ldc,druntime-ldc",
-        "-debuglib=phobos2-ldc-debug,druntime-ldc-debug"
     ];
+
+    // default rpath when linking against the shared default libs
+    rpath = "%%ldcbinarypath%%/../lib:%%ldcbinarypath%%/../lib32:%%ldcbinarypath%%/../lib64";
 };


### PR DESCRIPTION
This brings the packaged ldc2.conf in line with the upstream 1.9 builds.