### PR TITLE
Set LLVM_TARGETS_TO_BUILD to only include supported architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,6 +96,7 @@ parts:
     configflags:
     - -DCMAKE_BUILD_TYPE=Release
     - -DLLVM_BINUTILS_INCDIR=/usr/include
+    - -DLLVM_TARGETS_TO_BUILD=X86\;AArch64\;ARM\;PowerPC\;NVPTX
     stage:
     - -*
     prime:


### PR DESCRIPTION
This brings LLVM target support in line with the standard LDC binary builds.