### PR TITLE
Set LIB_SUFFIX according to host bitness

### DIFF
--- a/ldc-config/ldc2.conf
+++ b/ldc-config/ldc2.conf
@@ -13,12 +13,11 @@ default:
     post-switches = [
         "-I%%ldcbinarypath%%/../include/d/ldc",
         "-I%%ldcbinarypath%%/../include/d",
-        "-L-L%%ldcbinarypath%%/../lib",
-        "-L-L%%ldcbinarypath%%/../lib32",
         "-L-L%%ldcbinarypath%%/../lib64",
+        "-L-L%%ldcbinarypath%%/../lib32",
         "-L--no-warn-search-mismatch",
     ];
 
     // default rpath when linking against the shared default libs
-    rpath = "%%ldcbinarypath%%/../lib:%%ldcbinarypath%%/../lib32:%%ldcbinarypath%%/../lib64";
+    rpath = "%%ldcbinarypath%%/../lib64:%%ldcbinarypath%%/../lib32";
 };

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,6 +39,7 @@ parts:
         -DD_FLAGS='-w;-flto=thin' \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -Wa,-mrelax-relocations=no' \
+        -DLIB_SUFFIX="$(getconf LONG_BIT)" \
         -DLLVM_ROOT_DIR=../../llvm/install \
         -DBUILD_LTO_LIBS=ON \
         -DLDC_INSTALL_LTOPLUGIN=ON \


### PR DESCRIPTION
This should ensure that libraries are always placed in either `lib64` or `lib32`.  `ldc2.conf` has been simplified accordingly.