### PR TITLE
Remove deprecated elements from snap package definition

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,16 +15,12 @@ apps:
     command: bin/ldc2
   ldmd2:
     command: bin/ldmd2
-    aliases: [ldmd2]
   ldc-build-runtime:
     command: bin/ldc-build-runtime
-    aliases: [ldc-build-runtime]
   ldc-profdata:
     command: bin/ldc-profdata
-    aliases: [ldc-profdata]
   ldc-prune-cache:
     command: bin/ldc-prune-cache
-    aliases: [ldc-prune-cache]
 
 parts:
   ldc:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -117,4 +117,4 @@ parts:
     - python-pip
     - python-setuptools
     - unzip
-    prepare: pip install lit
+    override-build: pip install lit


### PR DESCRIPTION
The `prepare:` scriptlet section is now deprecated in favour of `override-build:`, while in-package alias definitions have been deprecated since snapcraft v2.35 (see also https://docs.snapcraft.io/deprecation-notices/dn5).  The latter have been maintained until now in order to support distros using older `snapd` versions, but can be dropped now since all supported distros seem to be using recent enough `snapd` releases.