### PR TITLE
Add CircleCI build config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+defaults: &defaults
+  working_directory: &workdir ~/workspace
+  docker:
+    - image: snapcore/snapcraft:stable
+
+version: 2
+jobs:
+  build:
+    <<: *defaults
+    steps:
+    - checkout
+
+    - run:
+        name: Update index
+        command: apt update
+
+    - run:
+        name: Build snap
+        command: snapcraft
+
+    - persist_to_workspace:
+      root: *workdir
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+    - build


### PR DESCRIPTION
This patch adds a basic CircleCI config file in line with the suggested setup provided by
https://tutorials.ubuntu.com/tutorial/continuous-snap-delivery-from-circle-ci

This version implements only the build stage, and does not attempt to push releases to the snap store; this will still be taken care of for now by the Launchpad build system.  Its intended usage is to test PRs and the current state of release branches.