### PR TITLE
Add CircleCI build config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,4 @@
 defaults: &defaults
-  parallelism: 1
   working_directory: &workdir ~/workspace
   docker:
     - image: snapcore/snapcraft:stable
@@ -17,15 +16,15 @@ jobs:
 
     - run:
         name: Build LLVM
-        command: snapcraft build llvm
+        command: snapcraft --no-parallel-builds build llvm
 
     - run:
         name: Build bootstrap LDC
-        command: snapcraft build ldc-bootstrap
+        command: snapcraft --no-parallel-builds build ldc-bootstrap
 
     - run:
         name: Build LDC snap package
-        command: snapcraft
+        command: snapcraft --no-parallel-builds
         environment: # compiler tests take too long for CircleCI's timeout
           SKIP_LDC_COMPILER_TESTS: 1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
     - run:
         name: Check snapcraft version
-        command: snapcraft --version && /snap/bin/snapcraft --version && snap info snapcraft
+        command: snapcraft --version && /snap/bin/snapcraft --version && nproc
 
     - run:
         name: Build LLVM
@@ -31,6 +31,7 @@ jobs:
         command: snapcraft --no-parallel-builds
         environment: # compiler tests take too long for CircleCI's timeout
           SKIP_LDC_COMPILER_TESTS: 1
+          LDC_COMPILER_BUILD_CPUS: 1
 
     - persist_to_workspace:
         root: *workdir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 defaults: &defaults
+  parallelism: 1
   working_directory: &workdir ~/workspace
   docker:
     - image: snapcore/snapcraft:stable
@@ -15,8 +16,16 @@ jobs:
         command: apt update
 
     - run:
-        name: Build snap
-        command: snapcraft --no-parallel-builds
+        name: Build LLVM
+        command: snapcraft build llvm
+
+    - run:
+        name: Build bootstrap LDC
+        command: snapcraft build ldc-bootstrap
+
+    - run:
+        name: Build LDC snap package
+        command: snapcraft
         environment: # compiler tests take too long for CircleCI's timeout
           SKIP_LDC_COMPILER_TESTS: 1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ jobs:
         command: apt update
 
     - run:
+        name: Check snapcraft version
+        command: snapcraft --version
+
+    - run:
         name: Build LLVM
         command: snapcraft --no-parallel-builds build llvm
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
     - run:
         name: Check snapcraft version
-        command: snapcraft --version && /snap/bin/snapcraft --version
+        command: snapcraft --version && /snap/bin/snapcraft --version && snap info snapcraft
 
     - run:
         name: Build LLVM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
     - run:
         name: Check snapcraft version
-        command: which snapcraft && snapcraft --version && ls -lahv /snap/bin/
+        command: snapcraft --version && /snap/bin/snapcraft --version
 
     - run:
         name: Build LLVM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
     - run:
         name: Check snapcraft version
-        command: snapcraft --version
+        command: which snapcraft && snapcraft --version && ls -lahv /snap/bin/
 
     - run:
         name: Build LLVM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ jobs:
     - run:
         name: Build snap
         command: snapcraft --no-parallel-builds
+        environment: # compiler tests take too long for CircleCI's timeout
+          SKIP_LDC_COMPILER_TESTS: 1
 
     - persist_to_workspace:
         root: *workdir

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+defaults: &defaults
+  working_directory: &workdir ~/workspace
+  docker:
+    - image: snapcore/snapcraft:stable
+
+version: 2
+jobs:
+  build:
+    <<: *defaults
+    steps:
+    - checkout
+
+    - run:
+        name: Update index
+        command: apt update
+
+    - run:
+        name: Build snap
+        command: snapcraft --no-parallel-builds
+
+    - persist_to_workspace:
+        root: *workdir
+        paths: ['*.snap']
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+    - build

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,13 +42,13 @@ parts:
         -DMULTILIB=ON \
         -DCMAKE_VERBOSE_MAKEFILE=1 \
         -GNinja
-      ninja -v
+      ninja -v -j "${LDC_COMPILER_BUILD_CPUS:=$(nproc)}"
       DESTDIR=../install ninja -v install
       if [ -z "${SKIP_LDC_COMPILER_TESTS}" ]; then
         echo "Skipping LDC compiler tests"
       else
         echo "Running LDC compiler tests"
-        ctest --output-on-failure --verbose -E "std\.net\.curl|std\.process|lit-tests"
+        ctest -j "${LDC_COMPILER_BUILD_CPUS}" --output-on-failure --verbose -E "std\.net\.curl|std\.process|lit-tests"
       fi
     stage:
     - -etc/ldc2.conf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,7 +44,12 @@ parts:
         -GNinja
       ninja -v
       DESTDIR=../install ninja -v install
-      ctest --output-on-failure --verbose -E "std\.net\.curl|std\.process|lit-tests"
+      if [ -z "${SKIP_LDC_COMPILER_TESTS}" ]; then
+        echo "Skipping LDC compiler tests"
+      else
+        echo "Running LDC compiler tests"
+        ctest --output-on-failure --verbose -E "std\.net\.curl|std\.process|lit-tests"
+      fi
     stage:
     - -etc/ldc2.conf
     build-packages:


### PR DESCRIPTION
This patch adds a basic CircleCI config file in line with the suggested setup provided by
https://tutorials.ubuntu.com/tutorial/continuous-snap-delivery-from-circle-ci

This version implements only the build stage, and does not attempt to push releases to the snap store; this will still be taken care of for now by the Launchpad build system.  Its intended usage is to test PRs and the current state of release branches.

This is a copy of https://github.com/ldc-developers/ldc2.snap/pull/59 rebased on and retargeted at the 1.10 branch to avoid potential CI issues.