### PR TITLE
Add basic CI support for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,17 @@
+pr:
+- 1.*
+
+jobs:
+- job: ldc2_snap
+  timeoutInMinutes: 0
+  pool:
+    vmImage: ubuntu-16.04
+  steps:
+  - script: |
+      set -x
+      snap version
+      lxd --version
+      sudo snap install --classic --stable snapcraft
+      /snap/bin/snapcraft --version
+      /snap/bin/snapcraft
+    displayName: Build ldc2 snap package


### PR DESCRIPTION
Since snapd is available in the Azure Ubuntu 16.04 image, we might as well keep it simple, install snapcraft as a snap package and run it.

This should pretty much match what happens on Launchpad, apart from the lack of LXD container.