### PR TITLE
Clean up unnecessary packages from ctest-setup

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -111,7 +111,4 @@ parts:
     - -*
     build-packages:
     - gdb
-    - python-pip
-    - python-setuptools
     - unzip
-    override-build: pip install lit


### PR DESCRIPTION
The python components in the setup are only required to run lit-tests.  Since these are currently disabled, we can just remove them for now and restore them should we ever want to re-enable those test cases.

Technically we could bundle the remaining `build-packages` into the `ldc` part, but keeping the `ctest-setup` part in place draws a nice clean line between packages required to build LDC itself, and packages only needed by the tests.