### PR TITLE
Add bash autocompletion for ldc2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ grade: stable
 apps:
   ldc2:
     command: bin/ldc2
+    completer: etc/bash_completion.d/ldc2
   ldmd2:
     command: bin/ldmd2
   ldc-build-runtime:


### PR DESCRIPTION
This patch takes advantage of snapcraft's support for tab completion via the app `completer:` field.  Unfortunately bash-completion settings are not currently available for the other apps, so cannot be included.