### PR TITLE
Add /snap/bin to path in Azure Pipelines build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ jobs:
       lxd --version
       sudo apt-get update
       sudo snap install --classic --candidate snapcraft
-      /snap/bin/snapcraft --version
-      /snap/bin/snapcraft
+      export PATH="${PATH}:/snap/bin"
+      snapcraft --version
+      snapcraft
     displayName: Build ldc2 snap package


### PR DESCRIPTION
This is a small tweak that avoids us having to explicitly invoke the full path to snapcraft, and may help in future if we need or want to install other snap packages to help the build.