### PR TITLE
Rework ldc-bootstrap to use the same compiler version as the release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ apps:
 parts:
   ldc:
     source: https://github.com/ldc-developers/ldc.git
-    source-tag: v1.11.0
+    source-tag: &ldc-version v1.11.0
     source-type: git
     plugin: cmake
     override-build: |
@@ -72,23 +72,28 @@ parts:
 
   ldc-bootstrap:
     source: https://github.com/ldc-developers/ldc.git
-    source-tag: v0.17.6
+    source-tag: *ldc-version
     source-type: git
     plugin: cmake
-    configflags:
-    - -DCMAKE_BUILD_TYPE=Release
-    - -DLLVM_ROOT_DIR=../../llvm/install
+    override-build: |
+      cmake ../src \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DD_COMPILER=ldmd2 \
+        -DLLVM_ROOT_DIR=../../llvm/install \
+        -GNinja
+      ninja
+      DESTDIR=../install ninja install
     stage:
     - -*
     prime:
     - -*
     build-packages:
     - g++
-    - libconfig++-dev
+    - ldc
     - libedit-dev
+    - ninja-build
     - zlib1g-dev
-    stage-packages:
-    - libconfig9
     after:
     - llvm
 


### PR DESCRIPTION
LDC v1.12.0+ supports LLVM 7, but v0.17.6 does not.  This means that to build more recent LDC releases with the latest LLVM we will either need to build multiple LLVMs (!) or change the bootstrap compiler.

This patch implements an alternative to the solution in https://github.com/ldc-developers/ldc2.snap/pull/75 using a technique already used by upstream LDC package builds: the bootstrap compiler is the same version as the one to be released, built with minimal features using the host system's LDC but the latest LLVM.  This means that we can take advantage of the most up to date compiler features when building the final release.

Note that an alternative would be to use `build-snaps` for the LDC used to build `ldc-bootstrap`.  This is avoided for now since avoiding having any snap-package dependencies should make it easier to build the package on a wider variety of systems.