### PR TITLE
Update to LDC 1.15.0 stable release, incl. LLVM 8.0.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ldc2
-version: 1.14.0
+version: 1.15.0
 summary: D compiler with LLVM backend
 description: |
     LDC is a portable compiler for the D programming Language, with
@@ -26,7 +26,7 @@ apps:
 parts:
   ldc:
     source: https://github.com/ldc-developers/ldc.git
-    source-tag: &ldc-version v1.14.0
+    source-tag: &ldc-version v1.15.0
     source-type: git
     plugin: cmake
     override-build: |
@@ -39,6 +39,7 @@ parts:
         -DLLVM_ROOT_DIR=../../llvm/install \
         -DBUILD_LTO_LIBS=ON \
         -DLDC_INSTALL_LTOPLUGIN=ON \
+        -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON \
         -DMULTILIB=ON \
         -DCMAKE_VERBOSE_MAKEFILE=1 \
         -GNinja
@@ -50,7 +51,6 @@ parts:
     build-packages:
     - gcc-multilib
     - g++-multilib
-    - libedit-dev
     - ninja-build
     - zlib1g-dev
     after:
@@ -89,7 +89,6 @@ parts:
     - -*
     build-packages:
     - g++
-    - libedit-dev
     - ninja-build
     - zlib1g-dev
     build-snaps:
@@ -99,7 +98,7 @@ parts:
 
   llvm:
     source: https://github.com/ldc-developers/llvm.git
-    source-tag: ldc-v7.0.1
+    source-tag: ldc-v8.0.0
     source-type: git
     plugin: cmake
     configflags:
@@ -108,6 +107,8 @@ parts:
     - -DLLVM_BINUTILS_INCDIR=/usr/include
     - -DLLVM_TARGETS_TO_BUILD=AArch64;ARM;Mips;MSP430;NVPTX;PowerPC;X86
     - -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=RISCV;WebAssembly
+    - -DLLVM_ENABLE_TERMINFO=OFF
+    - -DLLVM_ENABLE_LIBEDIT=OFF
     stage:
     - -*
     prime:


### PR DESCRIPTION
This is a dummy PR, just for making the 1.15 branch visible. Pinging @WebDrake.