### PR TITLE
Update to LDC 1.18.0 stable release and LLVM 9.0.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ldc2
-version: 1.17.0
+version: 1.18.0
 summary: D compiler with LLVM backend
 description: |
     LDC is a portable compiler for the D programming Language, with
@@ -26,7 +26,7 @@ apps:
 parts:
   ldc:
     source: https://github.com/ldc-developers/ldc.git
-    source-tag: &ldc-version v1.17.0
+    source-tag: &ldc-version v1.18.0
     source-type: git
     plugin: cmake
     override-build: |
@@ -98,7 +98,7 @@ parts:
 
   llvm:
     source: https://github.com/ldc-developers/llvm.git
-    source-tag: ldc-v8.0.1
+    source-tag: ldc-v9.0.0
     source-type: git
     plugin: cmake
     configflags:
@@ -109,6 +109,7 @@ parts:
     - -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=RISCV;WebAssembly
     - -DLLVM_ENABLE_TERMINFO=OFF
     - -DLLVM_ENABLE_LIBEDIT=OFF
+    - -DLLVM_INCLUDE_TESTS=OFF
     stage:
     - -*
     prime:


### PR DESCRIPTION
The LLVM 9 update requires a small tweak to CMake flags.

https://github.com/ldc-developers/ldc/releases/tag/v1.18.0
https://github.com/ldc-developers/llvm/releases/tag/ldc-v9.0.0