### PR TITLE
Add a base specifier to snapcraft.yaml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,5 +16,5 @@ jobs:
       export PATH="${PATH}:/snap/bin"
       sudo chown root:root /
       snapcraft --version
-      snapcraft
+      snapcraft --destructive-mode
     displayName: Build ldc2 snap package

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
     the official DMD compiler frontend to support the latest version
     of D2, and uses the LLVM Core libraries for code generation.
 
+base: core
 confinement: classic
 grade: stable
 


### PR DESCRIPTION
This should open up a number of new features, including the opportunity to specify license details in snap package metadata, and other snapcraft 3 features.

See https://snapcraft.io/docs/base-snaps for details on base snaps.  The `core` base is chosen so as to ensure compatibility with Ubuntu 16.04.

One impact of this is that the `snapcraft cleanbuild` command cannot be used any more.  Instead, builds are performed using `multipass`.  Azure Pipelines config has been updated accordingly.