### PR TITLE
Work around Azure Piplines build problems by chown'ing root directory

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ jobs:
       sudo apt-get update
       sudo snap install --classic --stable snapcraft
       export PATH="${PATH}:/snap/bin"
+      sudo chown root:root /
       snapcraft --version
       snapcraft
     displayName: Build ldc2 snap package

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,9 @@ parts:
         -GNinja
       ninja -v
       DESTDIR=../install ninja -v install
+      # Work around horrible DMD testsuite bug
+      sed -i 's/    2019/    __YEAR__/g' \
+          ../src/tests/d2/dmd-testsuite/compilable/extra-files/ddocYear.html
       ctest --output-on-failure --verbose -E "std\.net\.curl|std\.process|lit-tests"
     stage:
     - -etc/ldc2.conf


### PR DESCRIPTION
Using `chown` to set `root` as the owner of `/` was suggested on the snapcraft forums, and appears to work for others:
https://forum.snapcraft.io/t/permissions-problem-using-snapcraft-in-azure-pipelines/13258/14