### PR TITLE
Remove obsolete libedit details from LICENSE file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ jobs:
       sudo apt-get update
       sudo snap install --classic --stable snapcraft
       export PATH="${PATH}:/snap/bin"
+      sudo chown root:root /
       snapcraft --version
       snapcraft
     displayName: Build ldc2 snap package

--- a/doc/LICENSE
+++ b/doc/LICENSE
@@ -18,9 +18,6 @@ Compiler (bin/ in binary packages):
    University of Illinois Open Source License. A few LDC source files directly
    incorporate code derived from LLVM, see the file headers for details.
 
- - The snap-packaged LDC also statically links in libedit, which is distributed
-   under the terms of the 3-clause BSD license.
-
 Libraries (lib/ and include/d/ in the snap package):
  - The D standard library, comprised of druntime and Phobos, is distributed
    under the terms of the Boost Software License. See the individual source
@@ -546,41 +543,6 @@ necessary.  Here a sample; alter the names:
   Ty Coon, President of Vice
 
 That's all there is to it!
-
-
--- libedit license -------------------------------------------------------------
-
-Copyright:
-
-  Copyright (c) 1992, 1993
-    The Regents of the University of California.  All rights reserved.
-
-  This code is derived from software contributed to Berkeley by
-  Christos Zoulas of Cornell University.
-
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions
-  are met:
-  1. Redistributions of source code must retain the above copyright
-     notice, this list of conditions and the following disclaimer.
-  2. Redistributions in binary form must reproduce the above copyright
-     notice, this list of conditions and the following disclaimer in the
-     documentation and/or other materials provided with the distribution.
-  3. Neither the name of the University nor the names of its contributors
-     may be used to endorse or promote products derived from this software
-     without specific prior written permission.
-
-  THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-  ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
-  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-  SUCH DAMAGE.
 
 
 -- zlib license ----------------------------------------------------------------


### PR DESCRIPTION
`libedit` was dropped in commit 950fd5b1866b226fbb5a5cd35e4a6fa9ffec285e with the upgrade to LLVM 8.