### PR TITLE
Merge build fix and license updates from 1.15 branch into 1.16

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ jobs:
       sudo apt-get update
       sudo snap install --classic --stable snapcraft
       export PATH="${PATH}:/snap/bin"
+      sudo chown root:root /
       snapcraft --version
       snapcraft
     displayName: Build ldc2 snap package

--- a/doc/LICENSE
+++ b/doc/LICENSE
@@ -18,9 +18,6 @@ Compiler (bin/ in binary packages):
    University of Illinois Open Source License. A few LDC source files directly
    incorporate code derived from LLVM, see the file headers for details.
 
- - The snap-packaged LDC also statically links in libedit, which is distributed
-   under the terms of the 3-clause BSD license.
-
 Libraries (lib/ and include/d/ in the snap package):
  - The D standard library, comprised of druntime and Phobos, is distributed
    under the terms of the Boost Software License. See the individual source
@@ -546,41 +543,6 @@ necessary.  Here a sample; alter the names:
   Ty Coon, President of Vice
 
 That's all there is to it!
-
-
--- libedit license -------------------------------------------------------------
-
-Copyright:
-
-  Copyright (c) 1992, 1993
-    The Regents of the University of California.  All rights reserved.
-
-  This code is derived from software contributed to Berkeley by
-  Christos Zoulas of Cornell University.
-
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions
-  are met:
-  1. Redistributions of source code must retain the above copyright
-     notice, this list of conditions and the following disclaimer.
-  2. Redistributions in binary form must reproduce the above copyright
-     notice, this list of conditions and the following disclaimer in the
-     documentation and/or other materials provided with the distribution.
-  3. Neither the name of the University nor the names of its contributors
-     may be used to endorse or promote products derived from this software
-     without specific prior written permission.
-
-  THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-  ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
-  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-  SUCH DAMAGE.
 
 
 -- zlib license ----------------------------------------------------------------

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,9 @@ parts:
         -GNinja
       ninja -v
       DESTDIR=../install ninja -v install
+      # Work around horrible DMD testsuite bug
+      sed -i 's/    2019/    __YEAR__/g' \
+          ../src/tests/d2/dmd-testsuite/compilable/extra-files/ddocYear.html
       ctest --output-on-failure --verbose -E "std\.net\.curl|std\.process|lit-tests"
     stage:
     - -etc/ldc2.conf


### PR DESCRIPTION
This PR is just to confirm that CI passes.  The ddocYear test workaround has also been backported, as the test bug was introduced in LDC 1.16 (DMD 2.086).