### PR TITLE
Add compiler-rt settings to support baremetal builds and builtins

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -111,6 +111,8 @@ parts:
         -DCMAKE_INSTALL_PREFIX= \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_CXX_FLAGS=-static-libstdc++ \
+        -DCOMPILER_RT_BAREMETAL_BUILD=ON \
+        -DCOMPILER_RT_BUILD_BUILTINS=ON \
         -DCOMPILER_RT_INCLUDE_TESTS=OFF \
         -DCOMPILER_RT_USE_LIBCXX=OFF \
         -DLLVM_BINUTILS_INCDIR=/usr/include \


### PR DESCRIPTION
This should improve the cross-compiler support, for example if we want to build for ARM.

Part of https://github.com/ldc-developers/ldc2.snap/issues/97.

@denizzzka FYI.  Let's see if this addresses things.