### PR TITLE
Update ldc2.conf to better match upstream 1.18.0 binary package

### DIFF
--- a/ldc-config/ldc2.conf
+++ b/ldc-config/ldc2.conf
@@ -1,23 +1,49 @@
-// This configuration file uses libconfig.
-// See http://www.hyperrealm.com/libconfig/ for syntax details.
+// See comments in driver/config.d in ldc source tree for grammar description of
+// this config file.
 
-// The default group is required
+// For cross-compilation, you can add sections for specific target triples by
+// naming the sections as (quoted) regex patterns. See LDC's `-v` output
+// (`config` line) to figure out your normalized triple, depending on the used
+// `-mtriple`, `-m32` etc. E.g.:
+//
+//     "^arm.*-linux-gnueabihf$": { … };
+//     "86(_64)?-.*-linux": { … };
+//     "i[3-6]86-.*-windows-msvc": { … };
+//
+// Later sections take precedence and override settings from previous matching
+// sections while inheriting unspecified settings from previous sections.
+// A `default` section always matches (treated as ".*") and is therefore usually
+// the first section.
 default:
 {
     // default switches injected before all explicit command-line switches
     switches = [
         "-defaultlib=phobos2-ldc,druntime-ldc",
+        "-L--no-warn-search-mismatch",
     ];
 
     // default switches appended after all explicit command-line switches
     post-switches = [
         "-I%%ldcbinarypath%%/../include/d/ldc",
         "-I%%ldcbinarypath%%/../include/d",
-        "-L-L%%ldcbinarypath%%/../lib64",
-        "-L-L%%ldcbinarypath%%/../lib32",
-        "-L--no-warn-search-mismatch",
+    ];
+
+    // default directories to be searched for libraries when linking
+    lib-dirs = [
+        "%%ldcbinarypath%%/../lib64",
+        "%%ldcbinarypath%%/../lib32",
     ];
 
     // default rpath when linking against the shared default libs
     rpath = "%%ldcbinarypath%%/../lib64:%%ldcbinarypath%%/../lib32";
+};
+
+"^wasm(32|64)-":
+{
+    switches = [
+        "-defaultlib=",
+        "-link-internally",
+        "-L--export-dynamic",
+    ];
+    lib-dirs = [];
 };


### PR DESCRIPTION
This brings the config file in line with upstream standards.  It should be backwards compatible, while adding support for some extra settings, such as WebAssembly builds.

The `wasm` settings have one small difference from upstream: it uses `--link-internally` instead of `-link-internally`, on the assumption that the latter is a typo (the flag reported by `ldc2 --help` starts with `--`).

The precise diff with upstream:

```diff
23a24
> 
26c27,28
<         "-I%%ldcbinarypath%%/../import",
---
>         "-I%%ldcbinarypath%%/../include/d/ldc",
>         "-I%%ldcbinarypath%%/../include/d",
27a30
> 
30,31c33,34
<         "%%ldcbinarypath%%/../lib",
<         "%%ldcbinarypath%%/../lib32",
---
>         "-L-L%%ldcbinarypath%%/../lib64",
>         "-L-L%%ldcbinarypath%%/../lib32",
32a36
> 
34c38
<     rpath = "%%ldcbinarypath%%/../lib:%%ldcbinarypath%%/../lib32";
---
>     rpath = "%%ldcbinarypath%%/../lib64:%%ldcbinarypath%%/../lib32";
41c45
<         "-link-internally",
---
>         "--link-internally",
```