### PR TITLE
Simplify or remove override-build sections

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,22 +32,20 @@ parts:
     source-type: git
     source-depth: 1
     plugin: cmake
+    configflags:
+    - -DD_COMPILER=../../ldc-bootstrap/build/bin/ldmd2
+    - -DCMAKE_BUILD_TYPE=Release
+    - -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -Wa,-mrelax-relocations=no'
+    - -DLIB_SUFFIX=$$(getconf LONG_BIT)
+    - -DLLVM_ROOT_DIR=../../llvm/install
+    - -DBUILD_LTO_LIBS=ON
+    - -DLDC_INSTALL_LTOPLUGIN=ON
+    - -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON
+    - -DMULTILIB=ON
+    - -DCMAKE_VERBOSE_MAKEFILE=1
+    - -GNinja
     override-build: |
-      cmake ../src \
-        -DCMAKE_INSTALL_PREFIX= \
-        -DD_COMPILER=../../ldc-bootstrap/build/bin/ldmd2 \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -Wa,-mrelax-relocations=no' \
-        -DLIB_SUFFIX="$(getconf LONG_BIT)" \
-        -DLLVM_ROOT_DIR=../../llvm/install \
-        -DBUILD_LTO_LIBS=ON \
-        -DLDC_INSTALL_LTOPLUGIN=ON \
-        -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON \
-        -DMULTILIB=ON \
-        -DCMAKE_VERBOSE_MAKEFILE=1 \
-        -GNinja
-      ninja -v
-      DESTDIR=../install ninja -v install
+      snapcraftctl build
       # Work around horrible DMD testsuite bug
       sed -i 's/    2020/    __YEAR__/g' \
           ../src/tests/d2/dmd-testsuite/compilable/extra-files/ddocYear.html
@@ -83,15 +81,12 @@ parts:
     source-type: git
     source-depth: 1
     plugin: cmake
-    override-build: |
-      cmake ../src \
-        -DBUILD_SHARED_LIBS=OFF \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DD_COMPILER=ldmd2 \
-        -DLLVM_ROOT_DIR=../../llvm/install \
-        -GNinja
-      ninja
-      DESTDIR=../install ninja install
+    configflags:
+    - -DBUILD_SHARED_LIBS=OFF
+    - -DCMAKE_BUILD_TYPE=Release
+    - -DD_COMPILER=ldmd2
+    - -DLLVM_ROOT_DIR=../../llvm/install
+    - -GNinja
     stage:
     - -*
     prime:
@@ -110,24 +105,21 @@ parts:
     source-tag: ldc-v9.0.1
     source-type: git
     source-depth: 1
+    source-subdir: llvm
     plugin: cmake
-    override-build: |
-      cmake ../src/llvm \
-        -DCMAKE_INSTALL_PREFIX= \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_CXX_FLAGS=-static-libstdc++ \
-        -DCOMPILER_RT_INCLUDE_TESTS=OFF \
-        -DCOMPILER_RT_USE_LIBCXX=OFF \
-        -DLLVM_BINUTILS_INCDIR=/usr/include \
-        -DLLVM_TARGETS_TO_BUILD='AArch64;ARM;Mips;MSP430;NVPTX;PowerPC;RISCV;WebAssembly;X86' \
-        -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='AVR' \
-        -DLLVM_ENABLE_PROJECTS='compiler-rt;lld' \
-        -DLLVM_ENABLE_TERMINFO=OFF \
-        -DLLVM_ENABLE_LIBEDIT=OFF \
-        -DLLVM_INCLUDE_TESTS=OFF \
-        -GNinja
-      ninja
-      DESTDIR=../install ninja install
+    configflags:
+    - -DCMAKE_BUILD_TYPE=Release
+    - -DCMAKE_CXX_FLAGS=-static-libstdc++
+    - -DCOMPILER_RT_INCLUDE_TESTS=OFF
+    - -DCOMPILER_RT_USE_LIBCXX=OFF
+    - -DLLVM_BINUTILS_INCDIR=/usr/include
+    - -DLLVM_TARGETS_TO_BUILD='AArch64;ARM;Mips;MSP430;NVPTX;PowerPC;RISCV;WebAssembly;X86'
+    - -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD='AVR'
+    - -DLLVM_ENABLE_PROJECTS='compiler-rt;lld'
+    - -DLLVM_ENABLE_TERMINFO=OFF
+    - -DLLVM_ENABLE_LIBEDIT=OFF
+    - -DLLVM_INCLUDE_TESTS=OFF
+    - -GNinja
     stage:
     - -*
     prime:


### PR DESCRIPTION
`snapcraft` now actively supports using the ninja cmake backend, so in general we do not need to `override-build` to use this.  This allows us to go back to regular `configflags` settings for the `ldc-bootstrap` and `llvm` parts, although we have to add `source-subdir` settings to `llvm` because its `CMakeLists.txt` file is not in the source root.

For the `ldc` part we can move all the cmake config flags and simplify the `override-build` to just run `snapcraftctl build` followed by the search-and-replace dmd-testsuite workaround, and the call to `ctest`.

We also need to make one small tweak to the `ldc` part `configflags`: when setting `DLIB_SUFFIX`, we need to use `$$` to escape the `$` for ninja, and drop the surrounding quotes in order to ensure the scripted segment is passed to cmake correctly by snapcraft.