### PR TITLE
Drop unnecessary ctest-setup part

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,8 +58,10 @@ parts:
     - g++-multilib
     - ninja-build
     - zlib1g-dev
+    # needed only for ctest
+    - gdb
+    - unzip
     after:
-    - ctest-setup
     - ldc-bootstrap
     - llvm
   ldc-config:
@@ -131,13 +133,3 @@ parts:
     - binutils-dev
     - g++
     - ninja-build
-
-  ctest-setup:
-    plugin: nil
-    stage:
-    - -*
-    prime:
-    - -*
-    build-packages:
-    - gdb
-    - unzip


### PR DESCRIPTION
There is no need for this to be a standalone part, as all it does is to install a couple of build-packages.  These can be moved to `ldc`, which is the only real user, and highlighted as being ctest requirements.