### PR TITLE
Update to LDC 1.20.0 stable release

### DIFF
--- a/ldc-config/ldc2.conf
+++ b/ldc-config/ldc2.conf
@@ -19,7 +19,6 @@ default:
     // default switches injected before all explicit command-line switches
     switches = [
         "-defaultlib=phobos2-ldc,druntime-ldc",
-        "-L--no-warn-search-mismatch",
     ];
 
     // default switches appended after all explicit command-line switches
@@ -31,11 +30,10 @@ default:
     // default directories to be searched for libraries when linking
     lib-dirs = [
         "%%ldcbinarypath%%/../lib64",
-        "%%ldcbinarypath%%/../lib32",
     ];
 
     // default rpath when linking against the shared default libs
-    rpath = "%%ldcbinarypath%%/../lib64:%%ldcbinarypath%%/../lib32";
+    rpath = "%%ldcbinarypath%%/../lib64";
 };
 
 "^wasm(32|64)-":
@@ -46,4 +44,12 @@ default:
         "-L--export-dynamic",
     ];
     lib-dirs = [];
+};
+
+"i686-.*-linux-gnu":
+{
+    lib-dirs = [
+        "%%ldcbinarypath%%/../lib32",
+    ];
+    rpath = "%%ldcbinarypath%%/../lib32";
 };

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ldc2
-version: 1.19.0
+version: 1.20.1
 summary: D compiler with LLVM backend
 description: |
     LDC is a portable compiler for the D programming Language, with
@@ -28,7 +28,7 @@ apps:
 parts:
   ldc:
     source: https://github.com/ldc-developers/ldc.git
-    source-tag: &ldc-version v1.19.0
+    source-tag: &ldc-version v1.20.1
     source-type: git
     plugin: cmake
     override-build: |


### PR DESCRIPTION
`ldc2.conf` has been updated to bring it in line with the upstream LDC build, adding a separate section for 32-bit config and dropping the now unneeded `--no-warn-mismatch`.

https://github.com/ldc-developers/ldc/releases/tag/v1.20.0