### PR TITLE
Update ddocYear test workaround for LDC 1.20.x

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
       ninja -v
       DESTDIR=../install ninja -v install
       # Work around horrible DMD testsuite bug
-      sed -i 's/    2019/    __YEAR__/g' \
+      sed -i 's/    2020/    __YEAR__/g' \
           ../src/tests/d2/dmd-testsuite/compilable/extra-files/ddocYear.html
       ctest --output-on-failure --verbose -E "std\.net\.curl|std\.process|lit-tests"
     stage:


### PR DESCRIPTION
DMD 2.088.x introduced a nasty bug where the expected year in compiler test output was hardcoded.  DMD 2.090.x "fixed" this by updating the hardcoded year from 2019 to 2020.  This patch correspondingly tweaks our own workaround introduced in d80460670e77175ae0e42ec578b1727726b313db, which should be possible to remove with LDC 1.21+ (the upstream bug was fixed properly in DMD 2.091.x).