### PR TITLE
Add LTO flags to LDC build config

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,14 +35,17 @@ parts:
       cmake ../src \
         -DCMAKE_INSTALL_PREFIX= \
         -DD_COMPILER=../../ldc-bootstrap/build/bin/ldmd2 \
+        -DD_COMPILER_FLAGS='-flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto' \
+        -DEXTRA_CXXFLAGS='-flto=full' \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_FLAGS_RELEASE='-O3 -DNDEBUG -Wa,-mrelax-relocations=no' \
+        -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++ \
         -DLIB_SUFFIX="$(getconf LONG_BIT)" \
         -DLLVM_ROOT_DIR=../../llvm/install \
         -DBUILD_LTO_LIBS=ON \
         -DLDC_INSTALL_LTOPLUGIN=ON \
         -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON \
         -DMULTILIB=ON \
+        -DRT_CFLAGS='-Wa,-mrelax-relocations=no' \
         -DCMAKE_VERBOSE_MAKEFILE=1 \
         -GNinja
       ninja -v

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,7 @@ parts:
         -DCMAKE_INSTALL_PREFIX= \
         -DD_COMPILER=../../ldc-bootstrap/build/bin/ldmd2 \
         -DD_COMPILER_FLAGS='-flto=full -defaultlib=phobos2-ldc-lto,druntime-ldc-lto' \
-        -DEXTRA_CXXFLAGS='-flto=full' \
+        -DEXTRA_CXXFLAGS=-flto=full \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_EXE_LINKER_FLAGS=-static-libstdc++ \
         -DLIB_SUFFIX="$(getconf LONG_BIT)" \
@@ -45,7 +45,7 @@ parts:
         -DLDC_INSTALL_LTOPLUGIN=ON \
         -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON \
         -DMULTILIB=ON \
-        -DRT_CFLAGS='-Wa,-mrelax-relocations=no' \
+        -DRT_CFLAGS=-Wa,-mrelax-relocations=no \
         -DCMAKE_VERBOSE_MAKEFILE=1 \
         -GNinja
       ninja -v
@@ -89,6 +89,8 @@ parts:
         -DBUILD_SHARED_LIBS=OFF \
         -DCMAKE_BUILD_TYPE=Release \
         -DD_COMPILER=ldmd2 \
+        -DBUILD_LTO_LIBS=ON \
+        -DLDC_INSTALL_LTOPLUGIN=ON \
         -DLLVM_ROOT_DIR=../../llvm/install \
         -GNinja
       ninja

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,6 +91,7 @@ parts:
         -DD_COMPILER=ldmd2 \
         -DBUILD_LTO_LIBS=ON \
         -DLDC_INSTALL_LTOPLUGIN=ON \
+        -DLDC_INSTALL_LLVM_RUNTIME_LIBS=ON \
         -DLLVM_ROOT_DIR=../../llvm/install \
         -GNinja
       ninja


### PR DESCRIPTION
This brings the build of the `ldc` part in line with the upstream build setup.  Besides the LTO flags, some other CMake config flags have been reworked or added in line with upstream's Azure Pipelines CI settings.