### PR TITLE
Set source-depth to 1 to speed up git checkouts

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,7 @@ parts:
     source: https://github.com/ldc-developers/ldc.git
     source-tag: &ldc-version v1.20.1
     source-type: git
+    source-depth: 1
     plugin: cmake
     override-build: |
       cmake ../src \
@@ -80,6 +81,7 @@ parts:
     source: https://github.com/ldc-developers/ldc.git
     source-tag: *ldc-version
     source-type: git
+    source-depth: 1
     plugin: cmake
     override-build: |
       cmake ../src \
@@ -107,6 +109,7 @@ parts:
     source: https://github.com/ldc-developers/llvm-project.git
     source-tag: ldc-v9.0.1
     source-type: git
+    source-depth: 1
     plugin: cmake
     override-build: |
       cmake ../src/llvm \


### PR DESCRIPTION
There seems to be no reason to check out the full git history here and setting `source-depth: 1` for all git-sourced parts will both speed up builds and reduce the volume of unnecessary data downloads.

This can replace https://github.com/ldc-developers/ldc2.snap/pull/100 which is now outdated and targeted at an older branch.