### PR TITLE
Update to LDC 1.21.0 stable release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ldc2
-version: 1.20.1
+version: 1.21.0
 summary: D compiler with LLVM backend
 description: |
     LDC is a portable compiler for the D programming Language, with


### PR DESCRIPTION
The upstream package builds against LLVM 10, so we get this update for free in addition to the compiler version bump.