### PR TITLE
Update to LDC 1.24.0 stable release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ldc2
-version: 1.23.0
+version: 1.24.0
 summary: D compiler with LLVM backend
 description: |
     LDC is a portable compiler for the D programming Language, with


### PR DESCRIPTION
This brings the snap package up to date with the latest upstream stable
release, and as a consequence updates the backend to LLVM 11.