### PR TITLE
Prevent snapcraft patching RPATH for library dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,7 @@ parts:
     - on amd64: https://github.com/ldc-developers/ldc/releases/download/v$SNAPCRAFT_PROJECT_VERSION/ldc2-$SNAPCRAFT_PROJECT_VERSION-linux-x86_64.tar.xz
     - on arm64: https://github.com/ldc-developers/ldc/releases/download/v$SNAPCRAFT_PROJECT_VERSION/ldc2-$SNAPCRAFT_PROJECT_VERSION-linux-aarch64.tar.xz
     plugin: dump
+    build-attributes: [no-patchelf]
     organize:
       LICENSE: doc/LICENSE
     stage:


### PR DESCRIPTION
By default snapcraft will rewrite the RPATH of binaries to link against libraries in the core snap.  However, the prebuilt binaries used in the LDC package are designed and expected to link against host system libs.  To allow them to do this we need to explicitly instruct snapcraft using the `no-patchelf` build attribute.

For background see: https://forum.snapcraft.io/t/librt-so-1-undefined-symbol-clock-nanosleep/16246/2

This should allow LTO builds with LDC >= 1.21.0 to work on more recent systems (e.g. Ubuntu 20.04+).

Fixes https://github.com/ldc-developers/ldc2.snap/issues/121